### PR TITLE
Use the daemon_ensure parameter

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -100,6 +100,7 @@ class puppet::agent (
   else                 { $at_boot_ensure = 'absent'  }
 
   service { 'puppet_agent_daemon':
+    ensure => $daemon_ensure,
     name   => $daemon_name,
     enable => $daemon_enable,
   }


### PR DESCRIPTION
The daemon_ensure is set correctly in the puppet code, but the service definition doesn't use it.